### PR TITLE
Fix/metabase scalingo/metabase upgrade

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -92,7 +92,7 @@ fi
 
 if [ -n "$HEROKU" ]; then
     echo "  -> Heroku detected"
-    MAX_METASPACE_SIZE=${MAX_METASPACE_SIZE:-200m}
+    MAX_METASPACE_SIZE=${MAX_METASPACE_SIZE:-512m}
     # Set a few other options to minimize memory usage as much as possible.
     JAVA_OPTS+=" -XX:+UnlockExperimentalVMOptions"
     JAVA_OPTS+=" -XX:+UseContainerSupport"                 # Tell the JVM to use container info to set heap limit

--- a/bin/start
+++ b/bin/start
@@ -95,7 +95,7 @@ if [ -n "$HEROKU" ]; then
     MAX_METASPACE_SIZE=${MAX_METASPACE_SIZE:-130m}
     # Set a few other options to minimize memory usage as much as possible.
     JAVA_OPTS+=" -XX:+UnlockExperimentalVMOptions"
-    JAVA_OPTS+=" -XX:+UseCGroupMemoryLimitForHeap"         # Tell the JVM to use container info to set heap limit -- see https://devcenter.heroku.com/articles/java-memory-issues#configuring-java-to-run-in-a-container
+    JAVA_OPTS+=" -XX:+UseContainerSupport"                 # Tell the JVM to use container info to set heap limit
     JAVA_OPTS+=" -XX:-UseGCOverheadLimit"                  # Disable limit to amount of time spent in GC. Better slow than not working at all
     JAVA_OPTS+=" -XX:+UseCompressedOops"                   # Use 32-bit pointers. Reduces memory usage
     JAVA_OPTS+=" -XX:+UseCompressedClassPointers"          # Same as above. See also http://blog.leneghan.com/2012/03/reducing-java-memory-usage-and-garbage.html

--- a/bin/start
+++ b/bin/start
@@ -92,7 +92,7 @@ fi
 
 if [ -n "$HEROKU" ]; then
     echo "  -> Heroku detected"
-    MAX_METASPACE_SIZE=${MAX_METASPACE_SIZE:-130m}
+    MAX_METASPACE_SIZE=${MAX_METASPACE_SIZE:-200m}
     # Set a few other options to minimize memory usage as much as possible.
     JAVA_OPTS+=" -XX:+UnlockExperimentalVMOptions"
     JAVA_OPTS+=" -XX:+UseContainerSupport"                 # Tell the JVM to use container info to set heap limit

--- a/pom.xml
+++ b/pom.xml
@@ -17,10 +17,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.5.1</version>
+        <version>3.6.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
     </plugins>

--- a/scalingo.json
+++ b/scalingo.json
@@ -12,7 +12,7 @@
     },
     "MAX_METASPACE_SIZE": {
       "description": "Control max memory available",
-      "value": "512m"
+      "value": "200m"
     }
   },
   "addons": ["postgresql:postgresql-starter-512"]

--- a/scalingo.json
+++ b/scalingo.json
@@ -12,7 +12,7 @@
     },
     "MAX_METASPACE_SIZE": {
       "description": "Control max memory available",
-      "value": "200m"
+      "value": "512m"
     }
   },
   "addons": ["postgresql:postgresql-starter-512"]

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=17


### PR DESCRIPTION
Update:
- JDK to version 17.
- Maven Compiler Plugin to version 3.6.2.
- Java's Metaspace memory size to 512MB.

So that the latest Metabase version can be deployed using the one-click button.