### PR TITLE
Feature/metabase scalingo/csv plugin support

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,2 @@
 https://github.com/Scalingo/buildpack-jvm-common.git
 https://github.com/metabase/metabase-buildpack.git
-https://github.com/betagouv/metabase-scalingo.git#metabase-with-plugins

--- a/README.md
+++ b/README.md
@@ -52,11 +52,29 @@ $ git push scalingo master
 The following environment variables are available for you to adjust, depending
 on your needs:
 
-| Name                 | Description                                                                              | Default value                                   |
-| -------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| `BUILDPACK_URL`      | URL of the buildpack to use.                                                             | https://github.com/Scalingo/multi-buildpack.git |
-| `DATABASE_URL`       | URL of your database addon. **Only available if you have a database addon provisioned**. | Provided by Scalingo                            |
-| `MAX_METASPACE_SIZE` | Maximum amount of memory allocated to Java Metaspace[^1].                                | `512m` (512MB)                                  |
+| `BUILDPACK_URL` |                                                 |
+| --------------: | ----------------------------------------------- |
+| Description     | URL of the buildpack to use.                    |
+| Required        | Yes                                             |
+| Default         | https://github.com/Scalingo/multi-buildpack.git |
+
+| `DATABASE_URL` |                                                                                         |
+| -------------: | --------------------------------------------------------------------------------------- |
+| Description    | URL of the database addon. **Only available if you have a database addon provisioned.** |
+| Required       | No                                                                                      |
+| Default        | Provided by Scalingo.                                                                   |
+
+| `MAX_METASPACE_SIZE` |                                                           |
+| -------------------: | --------------------------------------------------------- |
+| Description          | Maximum amount of memory allocated to Java Metaspace[^1]. |
+| Required             | No                                                        |
+| Default              | `512m` (512MB)                                            |
+
+| `ENABLE_METABASE_CSV_PLUGIN` |                                                                                         |
+| ---------------------------: | --------------------------------------------------------------------------------------- |
+| Description                  | Whether to load the CSV driver plugin for Metabase or not.                              |
+| Required                     | No                                                                                      |
+| Default                      | `false` - **When defined**, anything but `false`, `FALSE` and `0` is considered `true`. |
 
 Metabase also [supports many environment variables](https://www.metabase.com/docs/latest/operations-guide/environment-variables.html).
 

--- a/bin/compile
+++ b/bin/compile
@@ -2,15 +2,34 @@
 
 set -eu
 
-METABASE_PLUGINS_DIR="$1/plugins"
-METABASE_CSV_PLUGIN_URL="https://github.com/Markenson/csv-metabase-driver/releases/download/v1.3.1/csv.metabase-driver.jar"
+metabase_plugin_csv_url="https://github.com/Markenson/csv-metabase-driver/releases/download/%s/csv.metabase-driver.jar"
+metabase_plugin_csv_version="v1.3.1"
 
-mkdir -p $METABASE_PLUGINS_DIR
 
-if [ "true" == $ENABLE_METABASE_CSV_PLUGIN ]
+is_true() {
+    if [[ "$1" = 0 ]]
+    then
+        false
+    elif [[ -z "$1" ]]
+    then
+        false
+    elif [[ "$1" =~ [Ff][Aa][Ll][Ss][Ee] ]]
+    then
+        false
+    fi
+}
+
+
+metabase_plugins_dir="${1}/plugins"
+mkdir -p "${metabase_plugins_dir}"
+
+
+printf -v mb_plugin_csv_url "${metabase_plugin_csv_url}" "${metabase_plugin_csv_version}"
+
+if is_true "${ENABLE_METABASE_CSV_PLUGIN}"
 then
     echo -n "- Install CSV plugin : "
-    cd $METABASE_PLUGINS_DIR
-    wget $METABASE_CSV_PLUGIN_URL    
+    cd "${metabase_plugins_dir}"
+    curl --location --remote-name "${mb_plugin_csv_url}"
     echo "Done"
 fi

--- a/bin/detect
+++ b/bin/detect
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-echo "Metabase Scalingo"
+echo "Metabase"
 exit 0

--- a/scalingo.json
+++ b/scalingo.json
@@ -13,6 +13,10 @@
     "MAX_METASPACE_SIZE": {
       "description": "Control max memory available",
       "value": "512m"
+    },
+    "ENABLE_METABASE_CSV_PLUGIN": {
+      "description": "Whether to load the CSV driver plugin or not",
+      "value": "false"
     }
   },
   "addons": ["postgresql:postgresql-starter-512"]


### PR DESCRIPTION
Add support for the CSV driver plugin, thanks to @jdauphant.
Update the `scalingo.json` and `README.md` files consequently.

Fixes #8