### PR TITLE
fix(deps): depend on Scalingo's Metabase buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
 https://github.com/Scalingo/buildpack-jvm-common.git
-https://github.com/metabase/metabase-buildpack.git
+https://github.com/Scalingo/metabase-buildpack.git


### PR DESCRIPTION
Following https://github.com/Scalingo/metabase-buildpack/pull/1

Fixes #17 